### PR TITLE
feature/LWB-9_token-query-parameter

### DIFF
--- a/api-gateway/src/main/java/org/linkwave/apigateway/security/AuthenticationHeaderGatewayFilter.java
+++ b/api-gateway/src/main/java/org/linkwave/apigateway/security/AuthenticationHeaderGatewayFilter.java
@@ -1,0 +1,54 @@
+package org.linkwave.apigateway.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.linkwave.apigateway.dto.ApiError;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.apache.http.HttpHeaders.AUTHORIZATION;
+import static org.linkwave.apigateway.security.utils.GatewayUtils.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@Component("authHeaderFilter")
+@RequiredArgsConstructor
+public class AuthenticationHeaderGatewayFilter implements GatewayFilter {
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    @SneakyThrows
+    @Override
+    public Mono<Void> filter(@NonNull ServerWebExchange exchange, @NonNull GatewayFilterChain chain) {
+        log.debug("-> filter()");
+        final List<String> header = exchange.getRequest()
+                .getHeaders()
+                .get(AUTHORIZATION);
+
+        if (header == null || !header.get(0).startsWith(BEARER_PREFIX)) {
+            final var response = exchange.getResponse();
+            final String error = objectMapper.writeValueAsString(ApiError.builder()
+                    .path(exchange.getRequest().getPath().value())
+                    .timestamp(Instant.now())
+                    .status(BAD_REQUEST.value())
+                    .message("Bearer is not present")
+                    .build());
+
+            return fillResponse(response, Mono.just(error), BAD_REQUEST);
+        }
+
+        return validateToken(exchange, chain, webClient, header.get(0));
+    }
+
+}

--- a/api-gateway/src/main/java/org/linkwave/apigateway/security/AuthenticationParameterGatewayFilter.java
+++ b/api-gateway/src/main/java/org/linkwave/apigateway/security/AuthenticationParameterGatewayFilter.java
@@ -1,0 +1,55 @@
+package org.linkwave.apigateway.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.linkwave.apigateway.dto.ApiError;
+import org.springframework.cloud.gateway.filter.GatewayFilter;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.linkwave.apigateway.security.utils.GatewayUtils.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@Slf4j
+@Component("authParamFilter")
+@RequiredArgsConstructor
+public class AuthenticationParameterGatewayFilter implements GatewayFilter {
+
+    public static final String TOKEN_PARAM_KEY = "access";
+
+    private final WebClient webClient;
+    private final ObjectMapper objectMapper;
+
+    @SneakyThrows
+    @Override
+    public Mono<Void> filter(@NonNull ServerWebExchange exchange, @NonNull GatewayFilterChain chain) {
+        log.debug("-> filter()");
+
+        final List<String> parameter = exchange.getRequest().getQueryParams().get(TOKEN_PARAM_KEY);
+
+        if (parameter == null || parameter.isEmpty() || parameter.get(0).isBlank()) {
+            log.debug("-> filter(): token not found");
+            final var response = exchange.getResponse();
+            final String error = objectMapper.writeValueAsString(ApiError.builder()
+                    .path(exchange.getRequest().getPath().value())
+                    .timestamp(Instant.now())
+                    .status(BAD_REQUEST.value())
+                    .message("Bearer is not present")
+                    .build());
+
+            return fillResponse(response, Mono.just(error), BAD_REQUEST);
+        }
+
+        return validateToken(exchange, chain, webClient, String.format("%s%s", BEARER_PREFIX, parameter.get(0)));
+    }
+
+}

--- a/api-gateway/src/main/java/org/linkwave/apigateway/security/utils/GatewayUtils.java
+++ b/api-gateway/src/main/java/org/linkwave/apigateway/security/utils/GatewayUtils.java
@@ -1,11 +1,6 @@
-package org.linkwave.apigateway.security;
+package org.linkwave.apigateway.security.utils;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import lombok.extern.slf4j.Slf4j;
-import org.linkwave.apigateway.dto.ApiError;
-import org.springframework.cloud.gateway.filter.GatewayFilter;
+import lombok.experimental.UtilityClass;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -15,48 +10,25 @@ import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Mono;
 
-import java.time.Instant;
-import java.util.List;
-
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.HttpHeaders.CONTENT_LENGTH;
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-@Slf4j
-@RequiredArgsConstructor
-public class AuthenticationGatewayFilter implements GatewayFilter {
+@UtilityClass
+public class GatewayUtils {
 
     public static final String BEARER_PREFIX = "Bearer ";
 
-    private final WebClient webClient;
-    private final ObjectMapper objectMapper;
-
-    @SneakyThrows
-    @Override
-    public Mono<Void> filter(@NonNull ServerWebExchange exchange, @NonNull GatewayFilterChain chain) {
-        log.debug("-> filter()");
-        final List<String> header = exchange.getRequest()
-                .getHeaders()
-                .get(AUTHORIZATION);
-
-        if (header == null || !header.get(0).startsWith(BEARER_PREFIX)) {
-            final var response = exchange.getResponse();
-            final String error = objectMapper.writeValueAsString(ApiError.builder()
-                    .path(exchange.getRequest().getPath().value())
-                    .timestamp(Instant.now())
-                    .status(BAD_REQUEST.value())
-                    .message("Bearer is not present")
-                    .build());
-
-            return fillResponse(response, Mono.just(error), BAD_REQUEST);
-        }
-
+    @NonNull
+    public static Mono<Void> validateToken(@NonNull ServerWebExchange exchange,
+                                           @NonNull GatewayFilterChain chain,
+                                           @NonNull WebClient webClient,
+                                           String token) {
         return webClient.get()
                 .uri("/api/v1/auth/validate-token")
-                .header(AUTHORIZATION, header.get(0))
+                .header(AUTHORIZATION, token)
                 .exchangeToMono(response -> {
                     if (response.statusCode().is2xxSuccessful()) {
                         return chain.filter(exchange);
@@ -67,7 +39,7 @@ public class AuthenticationGatewayFilter implements GatewayFilter {
     }
 
     @NonNull
-    private Mono<Void> fillResponse(@NonNull ServerHttpResponse response,
+    public static Mono<Void> fillResponse(@NonNull ServerHttpResponse response,
                                     @NonNull Mono<String> body,
                                     @NonNull HttpStatus status) {
         return response.writeWith(body.map(str -> {

--- a/ws-server/src/main/java/com/chat/wsserver/websocket/RootWebSocketHandler.java
+++ b/ws-server/src/main/java/com/chat/wsserver/websocket/RootWebSocketHandler.java
@@ -28,14 +28,14 @@ public class RootWebSocketHandler extends AbstractWebSocketHandler {
     @SneakyThrows
     @Override
     public void afterConnectionEstablished(@NonNull WebSocketSession session) {
-        sessionManager.persist(sessionConfigurer.getConcurrentSession(session));
+        sessionManager.persist(sessionConfigurer.configure(session));
     }
 
     @Override
     protected void handleTextMessage(@NonNull WebSocketSession session,
                                      @NonNull TextMessage message) throws IOException {
 
-        session = sessionConfigurer.getConcurrentSession(session);
+        session = sessionConfigurer.configure(session);
 
         log.debug("-> handleTextMessage()");
         try {
@@ -49,7 +49,7 @@ public class RootWebSocketHandler extends AbstractWebSocketHandler {
     @SneakyThrows
     @Override
     public void afterConnectionClosed(@NonNull WebSocketSession session, @NonNull CloseStatus status) {
-        sessionManager.remove(sessionConfigurer.getConcurrentSession(session));
+        sessionManager.remove(sessionConfigurer.configure(session));
     }
 
 }

--- a/ws-server/src/main/java/com/chat/wsserver/websocket/WebSocketSessionConfigurer.java
+++ b/ws-server/src/main/java/com/chat/wsserver/websocket/WebSocketSessionConfigurer.java
@@ -4,5 +4,5 @@ import org.springframework.lang.NonNull;
 import org.springframework.web.socket.WebSocketSession;
 
 public interface WebSocketSessionConfigurer {
-    WebSocketSession getConcurrentSession(@NonNull WebSocketSession session);
+    WebSocketSession configure(@NonNull WebSocketSession session);
 }

--- a/ws-server/src/main/java/com/chat/wsserver/websocket/WebSocketSessionConfigurerImpl.java
+++ b/ws-server/src/main/java/com/chat/wsserver/websocket/WebSocketSessionConfigurerImpl.java
@@ -16,7 +16,7 @@ public class WebSocketSessionConfigurerImpl implements WebSocketSessionConfigure
     private int bufferSizeLimit;
 
     @Override
-    public WebSocketSession getConcurrentSession(@NonNull WebSocketSession session) {
+    public WebSocketSession configure(@NonNull WebSocketSession session) {
         return new ConcurrentWebSocketSessionDecorator(session, sendTimeLimit, bufferSizeLimit);
     }
 

--- a/ws-server/src/main/java/com/chat/wsserver/websocket/jwt/JwtHandshakeHandler.java
+++ b/ws-server/src/main/java/com/chat/wsserver/websocket/jwt/JwtHandshakeHandler.java
@@ -9,9 +9,9 @@ import org.springframework.web.socket.server.support.AbstractHandshakeHandler;
 
 import java.security.Principal;
 import java.util.Map;
+import java.util.Optional;
 
-import static com.chat.wsserver.websocket.jwt.JwtHandshakeInterceptor.BEARER_PREFIX;
-import static com.chat.wsserver.websocket.jwt.JwtHandshakeInterceptor.JWT_HEADER_KEY;
+import static com.chat.wsserver.websocket.jwt.JwtHandshakeInterceptor.TOKEN_PARAM_KEY;
 
 @Component
 @RequiredArgsConstructor
@@ -24,12 +24,11 @@ public class JwtHandshakeHandler extends AbstractHandshakeHandler {
                                       @NonNull WebSocketHandler wsHandler,
                                       @NonNull Map<String, Object> attributes) {
 
-        final String rawToken = request.getHeaders()
-                .get(JWT_HEADER_KEY)
-                .get(0)
-                .substring(BEARER_PREFIX.length());
+        final var token = Optional.ofNullable(attributes.get(TOKEN_PARAM_KEY))
+                .map(Object::toString)
+                .orElseThrow(() -> new IllegalStateException("Not found access token"));
 
-        return new UserPrincipal(rawToken, tokenParser.parse(rawToken));
+        return new UserPrincipal(token, tokenParser.parse(token));
     }
 
 }


### PR DESCRIPTION
:warning: This pull request was issued due to the compatibility client **WebSocket API** with the server. The problem is that client **WebSocket API** does not support sending HTTP headers while connection initialization.

<br/>

:paperclip: Now you can initialize websocket connection via **API Gateway** using specified query parameter without Bearer prefix. Also it is possible to pass token by either Authorization header or access query parameter if connection is initiated directly (without **API Gateway**).