### PR TITLE
fix/LWB-18_docker-build-modules

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.8.6-openjdk-18 AS build
+FROM maven:3.8.6-openjdk-18
 WORKDIR /app
 COPY . .
 RUN mvn clean package spring-boot:repackage -DskipTests

--- a/backend/api-gateway/Dockerfile
+++ b/backend/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:18-jre-alpine
 WORKDIR /app
-COPY ./target/api-gateway-0.0.1-SNAPSHOT.jar ./api-gateway.jar
+COPY --from=linkwave/backend:latest ./app/api-gateway/target/api-gateway-0.0.1-SNAPSHOT.jar ./api-gateway.jar
 CMD ["java", "-jar", "api-gateway.jar"]

--- a/backend/auth-service/Dockerfile
+++ b/backend/auth-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:18-jre-alpine
 WORKDIR /app
-COPY ./target/auth-service-0.0.1-SNAPSHOT.jar ./auth-service.jar
+COPY --from=linkwave/backend:latest ./app/auth-service/target/auth-service-0.0.1-SNAPSHOT.jar ./auth-service.jar
 CMD ["java", "-jar", "auth-service.jar"]

--- a/backend/chat-service/Dockerfile
+++ b/backend/chat-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:18-jre-alpine
 WORKDIR /app
-COPY ./target/chat-service-0.0.1-SNAPSHOT.jar ./chat-service.jar
+COPY --from=linkwave/backend:latest ./app/chat-service/target/chat-service-0.0.1-SNAPSHOT.jar ./chat-service.jar
 CMD ["java", "-jar", "chat-service.jar"]

--- a/backend/discovery-service/Dockerfile
+++ b/backend/discovery-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:18-jre-alpine
 WORKDIR /app
-COPY ./target/discovery-service-0.0.1-SNAPSHOT.jar ./discovery-service.jar
+COPY --from=linkwave/backend:latest ./app/discovery-service/target/discovery-service-0.0.1-SNAPSHOT.jar ./discovery-service.jar
 CMD ["java", "-jar", "discovery-service.jar"]

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,17 +1,11 @@
 version: '3.9'
 services:
-  parent:
-    build:
-      context: .
-      dockerfile: Dockerfile
 
   discovery-service:
     container_name: "discovery-service"
     build: discovery-service
     ports:
       - "8761:8761"
-    depends_on:
-      - parent
     healthcheck:
       test: [ "CMD", "wget", "-qO-", "http://localhost:8761/actuator/health" ]
       interval: 10s
@@ -23,8 +17,6 @@ services:
     image: postgres:16.1-alpine
     ports:
       - "15432:5432"
-    depends_on:
-      - parent
     healthcheck:
       test: [ "CMD", "pg_isready", "-q", "-d", "lw-users", "-U", "postgres" ]
       interval: 5s

--- a/backend/shared/pom.xml
+++ b/backend/shared/pom.xml
@@ -26,6 +26,10 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-core</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -33,6 +37,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
                 <configuration>
                     <classifier>exec</classifier>
                 </configuration>

--- a/backend/user-service/Dockerfile
+++ b/backend/user-service/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:18-jre-alpine
 WORKDIR /app
-COPY ./target/user-service-0.0.1-SNAPSHOT.jar ./user-service.jar
+COPY --from=linkwave/backend:latest ./app/user-service/target/user-service-0.0.1-SNAPSHOT.jar ./user-service.jar
 CMD ["java", "-jar", "user-service.jar"]

--- a/backend/ws-server/Dockerfile
+++ b/backend/ws-server/Dockerfile
@@ -1,4 +1,4 @@
 FROM eclipse-temurin:18-jre-alpine
 WORKDIR /app
-COPY ./target/ws-0.0.1-SNAPSHOT.jar ./ws-server.jar
-CMD ["java", "-jar", "ws-server.jar"]
+COPY --from=linkwave/backend:latest ./app/ws-server/target/ws-0.0.1-SNAPSHOT.jar ./ws.jar
+CMD ["java", "-jar", "ws.jar"]


### PR DESCRIPTION
Previous pull request #29 related to deployment with **Docker** was a little bit confused but so for now it suffices to run these two commands to get it all work:

- :hammer: build an image that holds jars of the whole project
   `docker build -t linkwave/backend .`

- :rocket: run services
  `docker compose up`