### PR TITLE
feature/LWB-34_clear-chat-history

### DIFF
--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/chat/ChatMemberPermissionsDenied.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/chat/ChatMemberPermissionsDenied.java
@@ -1,0 +1,7 @@
+package org.linkwave.chatservice.chat;
+
+public class ChatMemberPermissionsDenied extends RuntimeException {
+    public ChatMemberPermissionsDenied() {
+        super("Permissions denied");
+    }
+}

--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/chat/ChatService.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/chat/ChatService.java
@@ -116,6 +116,8 @@ public interface ChatService {
 
     boolean isAdmin(Long memberId, @NonNull Chat chat);
 
+    void checkMemberRole(@NonNull Chat chat, Long memberId, ChatRole role) throws ChatMemberPermissionsDenied;
+
     ChatMember addGroupChatMember(Long userId, String chatId);
 
     void removeGroupChatMember(Long userId, String chatId);

--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/chat/ChatServiceImpl.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/chat/ChatServiceImpl.java
@@ -257,6 +257,14 @@ public class ChatServiceImpl implements ChatService {
     }
 
     @Override
+    public void checkMemberRole(@NonNull Chat chat, Long memberId, ChatRole role) throws ChatMemberPermissionsDenied {
+        final Optional<ChatMember> chatMember = findChatMember(memberId, chat);
+        if (chatMember.isEmpty() || chatMember.get().getRole() != role) {
+            throw new ChatMemberPermissionsDenied();
+        }
+    }
+
+    @Override
     public Optional<ChatMember> findChatMember(Long userId, @NonNull Chat chat) {
         return chat.getMembers()
                 .stream()

--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/common/RestExceptionHandler.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/common/RestExceptionHandler.java
@@ -3,6 +3,7 @@ package org.linkwave.chatservice.common;
 import jakarta.servlet.http.HttpServletRequest;
 import org.linkwave.chatservice.api.ApiResponseClientErrorException;
 import org.linkwave.chatservice.api.ServiceErrorException;
+import org.linkwave.chatservice.chat.ChatMemberPermissionsDenied;
 import org.linkwave.chatservice.chat.ChatNotFoundException;
 import org.linkwave.chatservice.message.MessageNotFoundException;
 import org.linkwave.shared.dto.ApiError;
@@ -74,7 +75,8 @@ public class RestExceptionHandler {
     @ResponseStatus(FORBIDDEN)
     @ExceptionHandler({
             PrivacyViolationException.class,
-            ChatOptionsViolationException.class
+            ChatOptionsViolationException.class,
+            ChatMemberPermissionsDenied.class
     })
     public ApiError handleForbiddenAccess(@NonNull RuntimeException e, @NonNull HttpServletRequest request) {
         return ApiError.builder()

--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageController.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageController.java
@@ -15,6 +15,7 @@ import java.util.List;
 
 import static org.linkwave.chatservice.common.RequestUtils.userDetails;
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
@@ -54,6 +55,12 @@ public class MessageController {
     @DeleteMapping("/messages/{id}")
     public RemovedMessage removeMessage(@PathVariable String id) {
         return messageService.removeMessage(userDetails().id(), id);
+    }
+
+    @DeleteMapping("/{chatId}/messages")
+    @ResponseStatus(NO_CONTENT)
+    public void clearMessages(@PathVariable String chatId) {
+        messageService.clearMessages(userDetails().id(), chatId);
     }
 
     @PatchMapping("/{chatId}/messages/readers")

--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageRepository.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageRepository.java
@@ -1,9 +1,14 @@
 package org.linkwave.chatservice.message;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MessageRepository extends MongoRepository<Message, String>, QuerydslPredicateExecutor<Message> {
+
+    @Query(value = "{ 'chat.$id': { $eq: ObjectId(?0) } }", delete = true)
+    void deleteAllChatMessages(String chatId);
+
 }

--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageService.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageService.java
@@ -21,6 +21,8 @@ public interface MessageService {
 
     RemovedMessage removeMessage(Long senderId, String messageId);
 
+    void clearMessages(Long senderId, String chatId);
+
     void updateMessage(@NonNull Message message);
 
     Message getMessage(String id);

--- a/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageServiceImpl.java
+++ b/backend/chat-service/src/main/java/org/linkwave/chatservice/message/MessageServiceImpl.java
@@ -2,6 +2,7 @@ package org.linkwave.chatservice.message;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.linkwave.chatservice.chat.ChatRole;
 import org.linkwave.chatservice.chat.ChatService;
 import org.linkwave.chatservice.chat.duo.Chat;
 import org.linkwave.chatservice.common.PrivacyViolationException;
@@ -162,6 +163,16 @@ public class MessageServiceImpl implements MessageService {
                 .messageId(messageId)
                 .createdAt(message.getCreatedAt())
                 .build();
+    }
+
+    @Transactional
+    @Override
+    public void clearMessages(Long senderId, String chatId) {
+        final Chat chat = chatService.findChat(chatId);
+        chatService.checkMemberRole(chat, senderId, ChatRole.ADMIN);
+        messageRepository.deleteAllChatMessages(chatId);
+        chat.setLastMessage(null);
+        chatService.updateChat(chat);
     }
 
     private void checkPermissions(Long userId, @NonNull Message message) {

--- a/backend/ws-server/README.MD
+++ b/backend/ws-server/README.MD
@@ -164,6 +164,27 @@ Response message example:
 
 <br/>
 
+### Clear chat history (`DUO` / `GROUP`)
+
+Message structure:
+
+```
+path=/chat/{chatId}/clear_history
+```
+
+Response message example:
+
+```json
+{
+  "action": "CLEAR_HISTORY",
+  "timestamp": 1712406700.330034700,
+  "senderId": 1,
+  "chatId": "66054151e162397346b28554"
+}
+```
+
+<br/>
+
 ### Read messages (`DUO` / `GROUP`)
 
 Message structure:

--- a/backend/ws-server/src/main/java/org/linkwave/ws/api/chat/ChatServiceClient.java
+++ b/backend/ws-server/src/main/java/org/linkwave/ws/api/chat/ChatServiceClient.java
@@ -77,6 +77,9 @@ public interface ChatServiceClient {
     @DeleteMapping("/messages/{id}")
     RemovedMessage removeMessage(@RequestHeader(AUTHORIZATION) String authHeader, @PathVariable String id);
 
+    @DeleteMapping("/{chatId}/messages")
+    void clearMessages(@RequestHeader(AUTHORIZATION) String authHeader, @PathVariable String chatId);
+
     @PatchMapping("/{chatId}/messages/readers")
     ReadMessages readMessages(
             @RequestHeader(AUTHORIZATION) String authHeader,

--- a/backend/ws-server/src/main/java/org/linkwave/ws/repository/ChatRepository.java
+++ b/backend/ws-server/src/main/java/org/linkwave/ws/repository/ChatRepository.java
@@ -35,6 +35,8 @@ public interface ChatRepository<U, C> extends SessionRepository<U> {
 
     Map<String, Integer> getUnreadMessages(U userId);
 
+    void setUnreadMessages(C chatId, Integer newValue);
+
     void changeUnreadMessages(C chatId, Set<U> membersIds, Integer delta);
 
     void changeUnreadMessages(C chatId, U userId, Integer delta);

--- a/backend/ws-server/src/main/java/org/linkwave/ws/repository/RedisChatRepository.java
+++ b/backend/ws-server/src/main/java/org/linkwave/ws/repository/RedisChatRepository.java
@@ -80,6 +80,18 @@ public class RedisChatRepository implements ChatRepository<Long, String> {
     }
 
     @Override
+    public void setUnreadMessages(String chatId, Integer newValue) {
+        final Set<Long> members = getMembers(chatId);
+        executeInTxn(
+                redisTemplate,
+                ops -> {
+                    final var hashOps = ops.opsForHash();
+                    members.forEach(id -> hashOps.put(userChatsKey(id), chatId, String.valueOf(newValue)));
+                }
+        );
+    }
+
+    @Override
     public void changeUnreadMessages(String chatId, Set<Long> membersIds, Integer delta) {
         executeInTxn(
                 redisTemplate,

--- a/backend/ws-server/src/main/java/org/linkwave/ws/websocket/dto/Action.java
+++ b/backend/ws-server/src/main/java/org/linkwave/ws/websocket/dto/Action.java
@@ -1,8 +1,18 @@
 package org.linkwave.ws.websocket.dto;
 
 public enum Action {
+
+    // Chat
     JOIN, LEAVE,
+
+    // User status
     ONLINE, OFFLINE,
-    MESSAGE, UPD_MESSAGE, READ, UNREAD_MESSAGES, BIND, REMOVE,
+
+    // Messages
+    MESSAGE, BIND, UPD_MESSAGE,
+    READ, UNREAD_MESSAGES,
+    REMOVE, CLEAR_HISTORY,
+
+    // Error
     ERROR
 }

--- a/backend/ws-server/src/main/java/org/linkwave/ws/websocket/routing/bpp/Broadcast.java
+++ b/backend/ws-server/src/main/java/org/linkwave/ws/websocket/routing/bpp/Broadcast.java
@@ -29,8 +29,8 @@ public @interface Broadcast {
      *          attached to specific route handler.
      *      </li>
      *      <li>
-     *          a field from received message for broadcast. In order to use this feature the {@code messageAnalysis}
-     *          property should be set to {@code true}.
+     *          a field from received message for broadcast. In order to use this feature the {@link Broadcast#analyzeMessage()}
+     *          should be set to {@code true}.
      *      </li>
      * </ul>
      */
@@ -42,5 +42,9 @@ public @interface Broadcast {
      */
     boolean analyzeMessage() default false;
 
-    boolean multiInstances() default false;
+    /**
+     * The message will be broadcasted to other instances if set to {@code true}, <br/>
+     * otherwise only locally.
+     */
+    boolean multiInstances() default true;
 }

--- a/backend/ws-server/src/main/java/org/linkwave/ws/websocket/routing/broadcast/SimpleBroadcastManager.java
+++ b/backend/ws-server/src/main/java/org/linkwave/ws/websocket/routing/broadcast/SimpleBroadcastManager.java
@@ -68,7 +68,7 @@ public class SimpleBroadcastManager implements BroadcastManager {
             isSharedCompletely = false;
         }
 
-        if (!isSharedCompletely) {
+        if (!isSharedCompletely && broadcastAnn.multiInstances()) {
             log.debug("-> process(): multi-instance broadcast is required");
 
             for (String instanceId : instances.split(separator)) {


### PR DESCRIPTION
## :memo: Implemented features

- [x] **Clear chat history**. Websocket action that used to delete all messages in the chat.

- [x] Support **multi-instances** property. Ability to broadcast message locally, i.e. message is only shared across sessions that attached to specific instance.